### PR TITLE
test: Add test scripts to test hello binding

### DIFF
--- a/helloworld-subscribe-event/helloworld-service-binding.c
+++ b/helloworld-subscribe-event/helloworld-service-binding.c
@@ -119,7 +119,7 @@ static const afb_verb_t verbs[] = {
 };
 
 const afb_binding_t afbBindingExport = {
-	.api = "helloworld",
+	.api = "helloworld-event",
 	.specification = NULL,
 	.verbs = verbs,
 	.preinit = NULL,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+###########################################################################
+# Copyright 2015 - 2018 IoT.bzh
+#
+# author: Romain Forlot <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###########################################################################
+
+
+# Include any directory not starting with _
+# -----------------------------------------------------
+PROJECT_SUBDIRS_ADD(${PROJECT_SRC_DIR_PATTERN})
+
+ADD_TEST(NAME AFB-TEST_TESTS
+	WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+	COMMAND afm-test "${CMAKE_BINARY_DIR}/package" "${CMAKE_BINARY_DIR}/package-test" SERVICE
+)

--- a/test/etc/CMakeLists.txt
+++ b/test/etc/CMakeLists.txt
@@ -1,0 +1,31 @@
+###########################################################################
+# Copyright 2015 - 2018 IoT.bzh
+#
+# author: Romain Forlot <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###########################################################################
+
+##################################################
+# Helloworld test configuration files
+##################################################
+PROJECT_TARGET_ADD(helloworld-config)
+
+	file(GLOB CONF_FILES "*.json")
+
+	add_input_files("${CONF_FILES}")
+
+	SET_TARGET_PROPERTIES(${TARGET_NAME} PROPERTIES
+	LABELS "TEST-CONFIG"
+	OUTPUT_NAME ${TARGET_NAME}
+	)

--- a/test/etc/aft-agl-helloworld.json
+++ b/test/etc/aft-agl-helloworld.json
@@ -1,0 +1,22 @@
+{
+    "id": "http://iot.bzh/download/public/schema/json/ctl-schema.json#",
+    "$schema": "http://iot.bzh/download/public/schema/json/ctl-schema.json#",
+    "metadata": {
+        "uid": "Hello_Test",
+        "version": "1.0",
+        "api": "aft-agl-helloworld",
+        "info": "Test part of Helloworld service binding",
+        "require": [
+            "helloworld"
+        ]
+    },
+    "testVerb": {
+        "uid": "testing-hello",
+        "info": "Launch the tests against hello api",
+        "action": "lua://AFT#_launch_test",
+        "args": {
+            "trace": "hello",
+            "files": ["helloworld.lua"]
+        }
+    }
+}

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+###########################################################################
+# Copyright 2015 - 2018 IoT.bzh
+#
+# author: Romain Forlot <romain.forlot@iot.bzh>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###########################################################################
+
+
+##################################################
+# Hellowolrd Lua Scripts
+##################################################
+PROJECT_TARGET_ADD(test-files)
+
+	file(GLOB LUA_FILES "*.lua")
+	add_input_files("${LUA_FILES}")
+
+	SET_TARGET_PROPERTIES(${TARGET_NAME} PROPERTIES
+	LABELS "TEST-DATA"
+	OUTPUT_NAME ${TARGET_NAME}
+	)

--- a/test/tests/helloworld.lua
+++ b/test/tests/helloworld.lua
@@ -19,41 +19,20 @@
 --]]
 
 function _callback(responseJ)
-  _AFT.assertStrContains(responseJ.response, "Some String")
+  _AFT.assertStrContains(responseJ.request.status, "success")
 end
 
 function _callbackError(responseJ)
-  _AFT.assertStrContains(responseJ.request.info, "Ping Binder Daemon fails")
-end
-function _callbackEvent(eventName, eventData)
-  _AFT.assertEquals(eventData, { key = 'weird others data', another_key = 123.456 })
+  _AFT.assertStrContains(responseJ.request.info, "verb pingfail unknown within api helloworld")
 end
 
-_AFT.addEventToMonitor("hello/anEvent")
-_AFT.addEventToMonitor("hello/anotherEvent", _callbackEvent)
-
-_AFT.testVerbStatusSuccess('testPingSuccess','hello', 'ping', {})
+_AFT.testVerbStatusSuccess('testPingSuccess','helloworld', 'ping', {})
 _AFT.setBefore("testPingSuccess",function() print("~~~~~ Begin testPingSuccess ~~~~~") end)
 _AFT.setAfter("testPingSuccess",function() print("~~~~~ End testPingSuccess ~~~~~") end)
 
-_AFT.testVerbResponseEquals('testPingSuccessAndResponse','hello', 'ping', {}, "Some String")
-_AFT.testVerbCb('testPingSuccessCallback','hello', 'ping', {}, _callback)
+_AFT.testVerbResponseEquals('testPingSuccessAndResponse','helloworld', 'ping', {}, "Ping count = %d")
+_AFT.testVerbCb('testPingSuccessCallback','helloworld', 'ping', {}, _callback)
 
-_AFT.testVerbStatusError('testPingError', 'hello', 'pingfail', {})
-_AFT.testVerbResponseEqualsError('testPingErrorAndResponse', 'hello', 'pingfail', {}, "Ping Binder Daemon succeeds")
-_AFT.testVerbCbError('testPingErrorCallback', 'hello', 'pingfail', {}, _callbackError)
-
-_AFT.testVerbStatusSuccess('testEventAddanEvent', 'hello', 'eventadd', {tag = 'event', name = 'anEvent'})
-_AFT.testVerbStatusSuccess('testEventSubanEvent', 'hello', 'eventsub', {tag = 'event'})
-_AFT.testVerbStatusSuccess('testEventPushanEvent', 'hello', 'eventpush', {tag = 'event', data = { key = 'some data', another_key = 123}})
-
-_AFT.testVerbStatusSuccess('testEventAddanotherEvent', 'hello', 'eventadd', {tag = 'evt', name = 'anotherEvent'})
-_AFT.testVerbStatusSuccess('testEventSubanotherEvent', 'hello', 'eventsub', {tag = 'evt'})
-_AFT.testVerbStatusSuccess('testEventPushanotherEvent', 'hello', 'eventpush', {tag = 'evt', data = { key = 'weird others data', another_key = 123.456}})
-
-_AFT.testVerbStatusSuccess('testGenerateWarning', 'hello', 'verbose', {level = 4, message = 'My Warning message!'})
-
-_AFT.testEvtGrpReceived("testEventGroupReceived",{["hello/anEvent"]=1,["hello/anotherEvent"]=1})
-
-_AFT.testEvtReceived("testanEventReceived", "hello/anEvent")
-_AFT.testEvtReceived("testanotherEventReceived", "hello/anotherEvent")
+_AFT.testVerbStatusError('testPingError', 'helloworld', 'pingfail', {})
+_AFT.testVerbResponseEqualsError('testPingErrorAndResponse', 'helloworld', 'pingfail', {}, "Ping Binder Daemon succeeds")
+_AFT.testVerbCbError('testPingErrorCallback', 'helloworld', 'pingfail', {}, _callbackError)

--- a/test/tests/helloworld.lua
+++ b/test/tests/helloworld.lua
@@ -1,0 +1,59 @@
+--[[
+    Copyright (C) 2018 "IoT.bzh"
+    Author Romain Forlot <romain.forlot@iot.bzh>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+    NOTE: strict mode: every global variables should be prefixed by '_'
+--]]
+
+function _callback(responseJ)
+  _AFT.assertStrContains(responseJ.response, "Some String")
+end
+
+function _callbackError(responseJ)
+  _AFT.assertStrContains(responseJ.request.info, "Ping Binder Daemon fails")
+end
+function _callbackEvent(eventName, eventData)
+  _AFT.assertEquals(eventData, { key = 'weird others data', another_key = 123.456 })
+end
+
+_AFT.addEventToMonitor("hello/anEvent")
+_AFT.addEventToMonitor("hello/anotherEvent", _callbackEvent)
+
+_AFT.testVerbStatusSuccess('testPingSuccess','hello', 'ping', {})
+_AFT.setBefore("testPingSuccess",function() print("~~~~~ Begin testPingSuccess ~~~~~") end)
+_AFT.setAfter("testPingSuccess",function() print("~~~~~ End testPingSuccess ~~~~~") end)
+
+_AFT.testVerbResponseEquals('testPingSuccessAndResponse','hello', 'ping', {}, "Some String")
+_AFT.testVerbCb('testPingSuccessCallback','hello', 'ping', {}, _callback)
+
+_AFT.testVerbStatusError('testPingError', 'hello', 'pingfail', {})
+_AFT.testVerbResponseEqualsError('testPingErrorAndResponse', 'hello', 'pingfail', {}, "Ping Binder Daemon succeeds")
+_AFT.testVerbCbError('testPingErrorCallback', 'hello', 'pingfail', {}, _callbackError)
+
+_AFT.testVerbStatusSuccess('testEventAddanEvent', 'hello', 'eventadd', {tag = 'event', name = 'anEvent'})
+_AFT.testVerbStatusSuccess('testEventSubanEvent', 'hello', 'eventsub', {tag = 'event'})
+_AFT.testVerbStatusSuccess('testEventPushanEvent', 'hello', 'eventpush', {tag = 'event', data = { key = 'some data', another_key = 123}})
+
+_AFT.testVerbStatusSuccess('testEventAddanotherEvent', 'hello', 'eventadd', {tag = 'evt', name = 'anotherEvent'})
+_AFT.testVerbStatusSuccess('testEventSubanotherEvent', 'hello', 'eventsub', {tag = 'evt'})
+_AFT.testVerbStatusSuccess('testEventPushanotherEvent', 'hello', 'eventpush', {tag = 'evt', data = { key = 'weird others data', another_key = 123.456}})
+
+_AFT.testVerbStatusSuccess('testGenerateWarning', 'hello', 'verbose', {level = 4, message = 'My Warning message!'})
+
+_AFT.testEvtGrpReceived("testEventGroupReceived",{["hello/anEvent"]=1,["hello/anotherEvent"]=1})
+
+_AFT.testEvtReceived("testanEventReceived", "hello/anEvent")
+_AFT.testEvtReceived("testanotherEventReceived", "hello/anotherEvent")


### PR DESCRIPTION
Scripts come from the app-afb-test binding example. They have been added
here to complete the demo example of helloworld binding.
Use the official documentation to build and launch the test :
http://docs.automotivelinux.org/master/docs/apis_services/en/dev/reference/afb-test/the-test-widget.html

Signed-off-by: Pierre MARZIN <pierre.marzin@iot.bzh>